### PR TITLE
Adding DLLs for PRT detections

### DIFF
--- a/WDACme.xml
+++ b/WDACme.xml
@@ -142,6 +142,8 @@
     <Deny ID="ID_DENY_D_2_1_8" FriendlyName="Windows Sockets Helper DLL" FilePath="wshbth.dll" />
     <Deny ID="ID_DENY_D_2_1_9" FriendlyName="Windows NT CRT DLL" FilePath="msvcrt.dll" />
     <Deny ID="ID_DENY_D_2_2_0" FriendlyName="Microsoft C Runtime Library" FilePath="msvcp_win.dll" />
+    <Deny ID="ID_DENY_D_2_2_1" FriendlyName="Request PRT via MicrosoftAccountTokenProvider.dll" FilePath="%SYSTEM32%\MicrosoftAccountTokenProvider.dll" />
+    <Deny ID="ID_DENY_D_2_2_2" FriendlyName="WinHello assertion request" FilePath="%SYSTEM32%\ncrypt.dll" />
   </FileRules>
   <!--Signers-->
   <Signers />
@@ -285,6 +287,8 @@
           <FileRuleRef RuleID="ID_DENY_D_2_1_8" />
           <FileRuleRef RuleID="ID_DENY_D_2_1_9" />
           <FileRuleRef RuleID="ID_DENY_D_2_2_0" />
+          <FileRuleRef RuleID="ID_DENY_D_2_2_1" />
+          <FileRuleRef RuleID="ID_DENY_D_2_2_2" />
         </FileRulesRef>
       </ProductSigners>
     </SigningScenario>


### PR DESCRIPTION
Hi, 

I know this project is not updated since two years, but I still like it a lot. I added two DLL's for PRT token stealing detections. Would be great to see them added here. 

FYI, exporting the CIP file is somehow failing for me since the latest release of App Control Wizard. Not sure if you have the same issue?

Kind regards
Robbe